### PR TITLE
SOLR-28: Add `created` attributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
 			<version>1.25.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>name.falgout.jeffrey.testing</groupId>
+			<artifactId>lambda-matcher</artifactId>
+			<version>0.2.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/test/java/org/musicbrainz/search/solrwriter/MBJSONWriterTestInterface.java
+++ b/src/test/java/org/musicbrainz/search/solrwriter/MBJSONWriterTestInterface.java
@@ -1,5 +1,7 @@
 package org.musicbrainz.search.solrwriter;
 
+import org.hamcrest.Matcher;
+
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.junit.Assert.assertThat;
 
@@ -16,6 +18,11 @@ public interface MBJSONWriterTestInterface extends MBWriterTestInterface {
 
 	@Override
 	default void compare(String expected, String actual) {
-		assertThat(actual, jsonEquals(expected));
+		Matcher isValidXMLGregorianCalendarMatcher =
+				MBWriterTestInterface.isValidXMLGregorianCalendarMatcher();
+		assertThat(actual, jsonEquals(expected).withMatcher
+				("validXMLGregorianCalendar",
+						isValidXMLGregorianCalendarMatcher));
 	}
+
 }

--- a/src/test/java/org/musicbrainz/search/solrwriter/MBWriterTestInterface.java
+++ b/src/test/java/org/musicbrainz/search/solrwriter/MBWriterTestInterface.java
@@ -1,5 +1,13 @@
 package org.musicbrainz.search.solrwriter;
 
+import name.falgout.jeffrey.testing.LambdaMatcher;
+import org.hamcrest.Matcher;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+
 public interface MBWriterTestInterface {
 	String uuid = "fff523fa-f2db-40eb-be81-f4544b43f39c";
 
@@ -21,4 +29,34 @@ public interface MBWriterTestInterface {
 	 * @param actual
 	 */
 	void compare(String expected, String actual);
+
+	/**
+	 *
+	 * @param value
+	 * @return True, if value can be converted to an XMLGregorianCalendar,
+	 * false otherwise.
+	 */
+	static boolean isValidXMLGregorianCalendarRepresentation(String value) {
+		try {
+			DatatypeFactory.
+					newInstance().
+					newXMLGregorianCalendar(value);
+		} catch (DatatypeConfigurationException e) {
+			e.printStackTrace();
+			return false;
+		}
+		return true;
+	}
+
+
+	/**
+	 * @return A Matcher that verifies if a String can be converted to a valid
+	 * XMLGregorianCalendar object.
+	 */
+	static Matcher isValidXMLGregorianCalendarMatcher() {
+		return LambdaMatcher.createMatcher
+				(MBWriterTestInterface
+								::isValidXMLGregorianCalendarRepresentation,
+						equalTo(true));
+	}
 }

--- a/src/test/java/org/musicbrainz/search/solrwriter/MBXMLWriterTestInterface.java
+++ b/src/test/java/org/musicbrainz/search/solrwriter/MBXMLWriterTestInterface.java
@@ -1,6 +1,7 @@
 package org.musicbrainz.search.solrwriter;
 
 import org.apache.solr.SolrTestCaseJ4;
+import org.w3c.dom.Attr;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.Diff;
@@ -23,12 +24,36 @@ public interface MBXMLWriterTestInterface extends MBWriterTestInterface {
 	default public void compare(String expected, String actual) {
 		Source test = Input.fromString(actual).build();
 
-		Diff d = DiffBuilder.compare(Input.fromString(expected)).withTest(test).build();
+		Diff d = DiffBuilder.compare(Input.fromString(expected))
+				.withTest(test)
+				.withAttributeFilter
+						(MBXMLWriterTestInterface::cannotSkipAttribute)
+				.build();
 		if (d.hasDifferences()) {
 			for (Difference diff : d.getDifferences()) {
 				System.err.println(diff.toString());
 			}
 		}
 		SolrTestCaseJ4.assertFalse(d.hasDifferences());
+	}
+
+	/**
+	 * Decides whether attr can not be skipped while comparing two XML
+	 * documents.
+	 *
+	 * @param attr
+	 * @return True if the attribute can not be skipped, false otherwise.
+	 */
+	static boolean cannotSkipAttribute(Attr attr) {
+		// Only metadata's created attribute is special at the moment.
+		if (attr.getName() != "created") {
+			return true;
+		}
+
+		boolean isValidXMLGregorianCalendarRepresentation =
+				MBWriterTestInterface
+						.isValidXMLGregorianCalendarRepresentation(attr
+								.getValue());
+		return !isValidXMLGregorianCalendarRepresentation;
 	}
 }

--- a/src/test/resources/org/musicbrainz/search/solrwriter/area-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/area-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "areas": [

--- a/src/test/resources/org/musicbrainz/search/solrwriter/artist-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/artist-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "artists": [

--- a/src/test/resources/org/musicbrainz/search/solrwriter/cdstub-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/cdstub-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "cdstubs": [

--- a/src/test/resources/org/musicbrainz/search/solrwriter/editor-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/editor-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "editors": [

--- a/src/test/resources/org/musicbrainz/search/solrwriter/label-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/label-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "labels": [

--- a/src/test/resources/org/musicbrainz/search/solrwriter/place-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/place-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "places": [

--- a/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "recordings": [

--- a/src/test/resources/org/musicbrainz/search/solrwriter/release-group-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/release-group-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "release-groups": [

--- a/src/test/resources/org/musicbrainz/search/solrwriter/release-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/release-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "releases": [

--- a/src/test/resources/org/musicbrainz/search/solrwriter/series-list.json
+++ b/src/test/resources/org/musicbrainz/search/solrwriter/series-list.json
@@ -1,4 +1,5 @@
 {
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
     "count": 1,
     "offset": 0,
     "series": [


### PR DESCRIPTION
This adds `created` attributes to both XML and JSON output, containing
the timestamp the search results were written.