### PR TITLE
SOLR-49: Handle SOLR errors in response writers

### DIFF
--- a/src/main/java/org/musicbrainz/search/solrwriter/MBError.java
+++ b/src/main/java/org/musicbrainz/search/solrwriter/MBError.java
@@ -1,0 +1,32 @@
+package org.musicbrainz.search.solrwriter;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlRootElement(name = "error")
+@XmlType(propOrder = {"code", "message"})
+public class MBError {
+
+    private int code;
+    private String message;
+
+    @XmlElement(name = "code")
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    @XmlElement(name = "message")
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+}

--- a/src/main/java/org/musicbrainz/search/solrwriter/MBError.java
+++ b/src/main/java/org/musicbrainz/search/solrwriter/MBError.java
@@ -7,11 +7,20 @@ import javax.xml.bind.annotation.XmlType;
 @XmlRootElement(name = "error")
 @XmlType(propOrder = {"code", "message"})
 public class MBError {
+    /**
+     * Custom XML bindings for JAXB to produce meaningful
+     * errors compatible with MB SolrQueryWriters in XML and
+     * JSON formats. It wraps SOLR Exceptions to a class that can
+     * be marshalled.
+     */
 
     private int code;
     private String message;
 
     @XmlElement(name = "code")
+    /**
+     * HTTP Error code returned by SOLR.
+     */
     public int getCode() {
         return code;
     }
@@ -21,6 +30,9 @@ public class MBError {
     }
 
     @XmlElement(name = "message")
+    /**
+     * Error string extracted from the SOLR exception
+     */
     public String getMessage() {
         return message;
     }

--- a/src/main/java/org/musicbrainz/search/solrwriter/MBJSONWriter.java
+++ b/src/main/java/org/musicbrainz/search/solrwriter/MBJSONWriter.java
@@ -77,11 +77,32 @@ public class MBJSONWriter extends MBXMLWriter {
 	}
 
 	@Override
+	protected JAXBContext createJAXBErrorContext() throws JAXBException {
+		Map<String, Object> properties = new HashMap<String, Object>();
+		properties
+				.put(JAXBContextProperties.MEDIA_TYPE, "application/json");
+		properties.put(JAXBContextProperties.JSON_INCLUDE_ROOT, true);
+		return JAXBContextFactory.createContext(
+				new Class[] { MBError.class }, properties);
+	}
+
+	@Override
+	protected Marshaller createErrorMarshaller() throws JAXBException {
+		if (errorContext == null) {
+			return null;
+		} else {
+			return errorContext.createMarshaller();
+		}
+	}
+
+	@Override
 	public void init(NamedList initArgs) {
 		super.init(initArgs);
 		try {
 			jsonContext = createJAXBJSONContext();
+			errorContext = createJAXBErrorContext();
 			marshaller = createMarshaller();
+			errorMarshaller = createErrorMarshaller();
 		} catch (JAXBException ex) {
 			throw new RuntimeException(ex);
 		}

--- a/src/main/java/org/musicbrainz/search/solrwriter/MBXMLWriter.java
+++ b/src/main/java/org/musicbrainz/search/solrwriter/MBXMLWriter.java
@@ -319,6 +319,19 @@ public class MBXMLWriter implements QueryResponseWriter {
 		}
 	}
 
+    private void writeResponse(Writer writer, MetadataListWrapper metadatalistwrapper)
+            throws IOException {
+        StringWriter sw = new StringWriter();
+        try {
+            marshaller.marshal(metadatalistwrapper.getCompletedMetadata(), sw);
+        } catch (JAXBException e) {
+            e.printStackTrace();
+            return;
+        }
+        writer.write(sw.toString());
+
+    }
+
 	public void write(Writer writer, SolrQueryRequest req, SolrQueryResponse res)
 			throws IOException {
 		MetadataListWrapper metadatalistwrapper = new MetadataListWrapper();
@@ -326,6 +339,11 @@ public class MBXMLWriter implements QueryResponseWriter {
 		NamedList vals = res.getValues();
 
 		ResultContext con = (ResultContext) vals.get("response");
+		if (con == null)
+		{
+			writeResponse(writer, metadatalistwrapper);
+			return;
+		}
 		DocList doclist = con.getDocList();
 
 		metadatalistwrapper.setCountAndOffset(doclist.matches(),

--- a/src/main/java/org/musicbrainz/search/solrwriter/MBXMLWriter.java
+++ b/src/main/java/org/musicbrainz/search/solrwriter/MBXMLWriter.java
@@ -135,7 +135,7 @@ public class MBXMLWriter implements QueryResponseWriter {
 				MMDList = objectfactory.createEventList();
 				objList = ((EventList) MMDList).getEvent();
 				break;
-  			case instrument:
+			case instrument:
 				MMDList = objectfactory.createInstrumentList();
 				objList = ((InstrumentList) MMDList).getInstrument();
 				break;
@@ -319,18 +319,18 @@ public class MBXMLWriter implements QueryResponseWriter {
 		}
 	}
 
-    private void writeResponse(Writer writer, MetadataListWrapper metadatalistwrapper)
-            throws IOException {
-        StringWriter sw = new StringWriter();
-        try {
-            marshaller.marshal(metadatalistwrapper.getCompletedMetadata(), sw);
-        } catch (JAXBException e) {
-            e.printStackTrace();
-            return;
-        }
-        writer.write(sw.toString());
+	private void writeResponse(Writer writer, MetadataListWrapper metadatalistwrapper)
+			throws IOException {
+		StringWriter sw = new StringWriter();
+		try {
+			marshaller.marshal(metadatalistwrapper.getCompletedMetadata(), sw);
+		} catch (JAXBException e) {
+			e.printStackTrace();
+			return;
+		}
+		writer.write(sw.toString());
 
-    }
+	}
 
 	public void write(Writer writer, SolrQueryRequest req, SolrQueryResponse res)
 			throws IOException {
@@ -339,11 +339,14 @@ public class MBXMLWriter implements QueryResponseWriter {
 		NamedList vals = res.getValues();
 
 		ResultContext con = (ResultContext) vals.get("response");
+		
 		if (con == null)
 		{
+			metadatalistwrapper.setCountAndOffset(0, 0);
 			writeResponse(writer, metadatalistwrapper);
 			return;
 		}
+
 		DocList doclist = con.getDocList();
 
 		metadatalistwrapper.setCountAndOffset(doclist.matches(),


### PR DESCRIPTION
Still figuring out the correct way to deal with this.

Currently this returns a blank response when an invalid search field is given. Do we have a response format for errors in Search? If yes, I would like to extract the error and simply display that when it is present.

Not sure if my way is the most optimal since currently it just hides the problem.