### PR TITLE
Add a solr-data volume to the compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8983:8983"
+    volumes:
+      - solr-data:/opt/solr/server/solr/data
+
+volumes:
+  solr-data:


### PR DESCRIPTION
So that index data is preserved when the container is recreated.

I followed the example from https://hub.docker.com/_/solr/